### PR TITLE
Fix for Using 'GetPlayerStatsAsync' for user 'ImPants' throws exception

### DIFF
--- a/ChessDotComSharp/Models/Player/PlayerStats.cs
+++ b/ChessDotComSharp/Models/Player/PlayerStats.cs
@@ -54,7 +54,7 @@ namespace ChessDotComSharp.Models
         /// <summary>
         /// Timeout percentage in the last 90 days
         /// </summary>
-        [J("timeout_percent")] public int TimeoutPercent { get; set; }
+        [J("timeout_percent")] public double TimeoutPercent { get; set; }
     }
 
     public partial class TournamentRecord


### PR DESCRIPTION
Input string '2.17' is not a valid integer. Path 'chess_daily.record.timeout_percent', line 1, position 242.