### PR TITLE
Include game accuracies

### DIFF
--- a/ChessDotComSharp/ChessDotComSharp.csproj
+++ b/ChessDotComSharp/ChessDotComSharp.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Description>A .NET wrapper for Chess.com's API</Description>
     <Company>Ambersoft Labs</Company>
     <Authors>Kurt Gooding</Authors>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/ChessDotComSharp/Models/Game.cs
+++ b/ChessDotComSharp/Models/Game.cs
@@ -8,6 +8,7 @@ namespace ChessDotComSharp.Models
     public class GameBase
     {
         [J("url")] public string Url { get; set; }
+        [J("accuracies")] public Accuracies Accuracies { get; set; }
         [J("pgn")] public string Pgn { get; set; }
         /// <summary>
         /// Specific time control used in the game, in the PGN standard notation <seealso cref="http://www.saremba.de/chessgml/standards/pgn/pgn-complete.htm#c9.6"/> 

--- a/ChessDotComSharp/Models/Player/Player.cs
+++ b/ChessDotComSharp/Models/Player/Player.cs
@@ -16,6 +16,7 @@ namespace ChessDotComSharp.Models
         [J("@id")] public string Id { get; set; }
         [J("name")] public string Name { get; set; }
         [J("username")] public string Username { get; set; }
+        [J("url")] public string Url { get; set; }
         [J("followers")] public int Followers { get; set; }
         [J("country")] public string Country { get; set; }
         [J("location")] public string Location { get; set; }

--- a/ChessDotComSharp/Models/Player/PlayerGames.cs
+++ b/ChessDotComSharp/Models/Player/PlayerGames.cs
@@ -33,6 +33,12 @@ namespace ChessDotComSharp.Models
         [J("username")] public string Username { get; set; }
     }
 
+    public partial class Accuracies
+    {
+        [J("white")] public float? White { get; set; }
+        [J("black")] public float? Black { get; set; }
+    }
+
     public partial class ActiveGame : GameBase
     {
         /// <summary>


### PR DESCRIPTION
- The game archive now includes Accuracies (see https://www.chess.com/clubs/forum/view/game-accuracy-not-included-in-pgns-how-do-i-extract-this-value-from-downloaded-pgns comment #16)

- Added url to PlayerProfile